### PR TITLE
Bigint

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,6 +657,7 @@ if (result === null) {
 ### Property Types
 
 - **`primitive`**: Strings, numbers, booleans, enums
+- **`bigint`**: BigInts (typically uint64s used to store nanoseconds)
 - **`array`**: Arrays of values
 - **`object`**: GStreamer structures (like stats)
 - **`buffer`**: Raw binary data

--- a/src/ts/element-props.test.ts
+++ b/src/ts/element-props.test.ts
@@ -67,6 +67,25 @@ describe.concurrent("Element Properties", () => {
     expect(numBuffers?.value).toBe(100);
   });
 
+  it("should set bigint property", () => {
+    const pipeline = new Pipeline("videotestsrc ! queue name=q ! fakesink");
+    const queue = pipeline.getElementByName("q");
+
+    if (!queue) throw new Error("Element not found");
+
+    // Test setting num-buffers property with bigint
+    queue.setElementProperty("max-size-time", 1000000000n);
+    const maxSizeTime = queue.getElementProperty("max-size-time");
+    expect(maxSizeTime?.type).toBe("bigint");
+    expect(maxSizeTime?.value).toBe(1000000000n);
+
+    // Test setting num-buffers property with number
+    queue.setElementProperty("max-size-time", 1000);
+    const maxSizeTime2 = queue.getElementProperty("max-size-time");
+    expect(maxSizeTime2?.type).toBe("bigint");
+    expect(maxSizeTime2?.value).toBe(1000n);
+  });
+
   it("should set caps property", () => {
     const pipeline = new Pipeline("videotestsrc ! capsfilter name=filter ! fakesink");
     const element = pipeline.getElementByName("filter");

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -59,6 +59,7 @@ export type GStreamerPropertyReturnValue =
 
 export type GStreamerPropertyResult =
   | { type: "primitive"; value: GStreamerPropertyValue }
+  | { type: "bigint"; value: GStreamerPropertyValue }
   | { type: "array"; value: GStreamerPropertyValue[] }
   | { type: "object"; value: Record<string, GStreamerPropertyValue> }
   | { type: "buffer"; value: Buffer }


### PR DESCRIPTION
Hi! Thank you for making this library. Amazing timing -- I was just looking for an updated gstreamer-superficial a few weeks ago and found nothing!

While porting [some existing gstreamer-superficial code](https://github.com/streamwall/streamdelay/blob/1d996a60a31915e6c3e765e569ab74ccd48ca6bd/index.js), I ran into type conversion errors for uint64s used to represent times in queue elements. Here's a quick PR to add support for the conversion to/from JS native bigints.