### PR TITLE
Convert GValueArray values for structure keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -919,9 +919,8 @@ if (result === null) {
 
 ### Property Types
 
-- **`primitive`**: Strings, numbers, booleans, enums
-- **`bigint`**: BigInts (typically uint64s used to store nanoseconds)
-- **`array`**: Arrays of values
+- **`primitive`**: strings, numbers, booleans, bigint (typically uint64s used to store nanoseconds)
+- **`array`**: Arrays of primitive values (strings, numbers, booleans, bigints)
 - **`object`**: GStreamer structures (like stats)
 - **`buffer`**: Raw binary data
 - **`sample`**: Media samples with buffer, caps, and metadata

--- a/src/cpp/type-conversion.cpp
+++ b/src/cpp/type-conversion.cpp
@@ -299,15 +299,12 @@ namespace TypeConversion {
         const GstStructure *structure = GST_STRUCTURE(boxed_value);
         return gst_structure_to_js(env, structure);
       } else if (boxed_value && strcmp(g_type_name(G_VALUE_TYPE(gvalue)), "GValueArray") == 0) {
-        // Only cast to GValueArray if we're certain it's actually a GValueArray
         GValueArray *arr = static_cast<GValueArray *>(boxed_value);
-        if (arr) { // sanity check with null check
-          Napi::Array js_arr = Napi::Array::New(env, arr->n_values);
-          for (guint i = 0; i < arr->n_values; i++) {
-            js_arr.Set(i, gvalue_to_js(env, &arr->values[i]));
-          }
-          return js_arr;
+        Napi::Array js_arr = Napi::Array::New(env, arr->n_values);
+        for (guint i = 0; i < arr->n_values; i++) {
+          js_arr.Set(i, gvalue_to_js(env, &arr->values[i]));
         }
+        return js_arr;
       }
     }
 

--- a/src/cpp/type-conversion.cpp
+++ b/src/cpp/type-conversion.cpp
@@ -298,7 +298,7 @@ namespace TypeConversion {
         // Handle GstStructure (like stats property)
         const GstStructure *structure = GST_STRUCTURE(boxed_value);
         return gst_structure_to_js(env, structure);
-      } else if (boxed_value && std::string(g_type_name(G_VALUE_TYPE(gvalue))) == "GValueArray") {
+      } else if (boxed_value && strcmp(g_type_name(G_VALUE_TYPE(gvalue)), "GValueArray") == 0) {
         // Only cast to GValueArray if we're certain it's actually a GValueArray
         GValueArray *arr = static_cast<GValueArray *>(boxed_value);
         if (arr && arr->n_values > 0) { // sanity check with null check

--- a/src/cpp/type-conversion.cpp
+++ b/src/cpp/type-conversion.cpp
@@ -302,11 +302,11 @@ namespace TypeConversion {
         // Only cast to GValueArray if we're certain it's actually a GValueArray
         GValueArray *arr = static_cast<GValueArray *>(boxed_value);
         if (arr && arr->n_values > 0) { // sanity check with null check
-          Napi::Array jsArr = Napi::Array::New(env, arr->n_values);
+          Napi::Array js_arr = Napi::Array::New(env, arr->n_values);
           for (guint i = 0; i < arr->n_values; i++) {
-            jsArr.Set(i, gvalue_to_js(env, &arr->values[i]));
+            js_arr.Set(i, gvalue_to_js(env, &arr->values[i]));
           }
-          return jsArr;
+          return js_arr;
         }
       }
     }

--- a/src/cpp/type-conversion.cpp
+++ b/src/cpp/type-conversion.cpp
@@ -298,7 +298,7 @@ namespace TypeConversion {
         // Handle GstStructure (like stats property)
         const GstStructure *structure = GST_STRUCTURE(boxed_value);
         return gst_structure_to_js(env, structure);
-      } else if (boxed_value && G_VALUE_TYPE(gvalue) == G_TYPE_VALUE_ARRAY) {
+      } else if (boxed_value && std::string(g_type_name(G_VALUE_TYPE(gvalue))) == "GValueArray") {
         // Only cast to GValueArray if we're certain it's actually a GValueArray
         GValueArray *arr = static_cast<GValueArray *>(boxed_value);
         if (arr && arr->n_values > 0) { // sanity check with null check

--- a/src/cpp/type-conversion.cpp
+++ b/src/cpp/type-conversion.cpp
@@ -329,10 +329,8 @@ namespace TypeConversion {
     Napi::Object result = Napi::Object::New(env);
 
     // Determine the type and set both type and value
-    if (js_value.IsString() || js_value.IsNumber() || js_value.IsBoolean()) {
+    if (js_value.IsString() || js_value.IsNumber() || js_value.IsBoolean() || js_value.IsBigInt()) {
       result.Set("type", Napi::String::New(env, "primitive"));
-    } else if (js_value.IsBigInt()) {
-      result.Set("type", Napi::String::New(env, "bigint"));
     } else if (js_value.IsArray()) {
       result.Set("type", Napi::String::New(env, "array"));
     } else if (js_value.IsBuffer()) {

--- a/src/cpp/type-conversion.cpp
+++ b/src/cpp/type-conversion.cpp
@@ -298,6 +298,16 @@ namespace TypeConversion {
         // Handle GstStructure (like stats property)
         const GstStructure *structure = GST_STRUCTURE(boxed_value);
         return gst_structure_to_js(env, structure);
+      } else if (boxed_value && g_type_is_a(G_VALUE_TYPE(gvalue), G_TYPE_BOXED)) {
+        // Try casting to GValueArray
+        GValueArray *arr = static_cast<GValueArray *>(boxed_value);
+        if (arr->n_values > 0) { // sanity check
+          Napi::Array jsArr = Napi::Array::New(env, arr->n_values);
+          for (guint i = 0; i < arr->n_values; i++) {
+            jsArr.Set(i, gvalue_to_js(env, &arr->values[i]));
+          }
+          return jsArr;
+        }
       }
     }
 

--- a/src/cpp/type-conversion.cpp
+++ b/src/cpp/type-conversion.cpp
@@ -301,7 +301,7 @@ namespace TypeConversion {
       } else if (boxed_value && strcmp(g_type_name(G_VALUE_TYPE(gvalue)), "GValueArray") == 0) {
         // Only cast to GValueArray if we're certain it's actually a GValueArray
         GValueArray *arr = static_cast<GValueArray *>(boxed_value);
-        if (arr && arr->n_values > 0) { // sanity check with null check
+        if (arr) { // sanity check with null check
           Napi::Array js_arr = Napi::Array::New(env, arr->n_values);
           for (guint i = 0; i < arr->n_values; i++) {
             js_arr.Set(i, gvalue_to_js(env, &arr->values[i]));

--- a/src/cpp/type-conversion.cpp
+++ b/src/cpp/type-conversion.cpp
@@ -298,10 +298,10 @@ namespace TypeConversion {
         // Handle GstStructure (like stats property)
         const GstStructure *structure = GST_STRUCTURE(boxed_value);
         return gst_structure_to_js(env, structure);
-      } else if (boxed_value && g_type_is_a(G_VALUE_TYPE(gvalue), G_TYPE_BOXED)) {
-        // Try casting to GValueArray
+      } else if (boxed_value && G_VALUE_TYPE(gvalue) == G_TYPE_VALUE_ARRAY) {
+        // Only cast to GValueArray if we're certain it's actually a GValueArray
         GValueArray *arr = static_cast<GValueArray *>(boxed_value);
-        if (arr->n_values > 0) { // sanity check
+        if (arr && arr->n_values > 0) { // sanity check with null check
           Napi::Array jsArr = Napi::Array::New(env, arr->n_values);
           for (guint i = 0; i < arr->n_values; i++) {
             jsArr.Set(i, gvalue_to_js(env, &arr->values[i]));

--- a/src/ts/bus-pop.test.ts
+++ b/src/ts/bus-pop.test.ts
@@ -134,4 +134,23 @@ describe.concurrent("Pipeline busPop Method", () => {
       expect(typeof messageWithStructure.structureName).toBe("string");
     }
   });
+
+  it("should receive message with array property type", async () => {
+    const pipeline = new Pipeline(
+      `audiotestsrc wave=ticks tick-interval=400000000 num-buffers=50 ` +
+        `! level name=lev ! fakeaudiosink`
+    );
+
+    await pipeline.play();
+
+    let message: Awaited<ReturnType<typeof pipeline.busPop>> = null;
+
+    do {
+      message = await pipeline.busPop();
+    } while (message?.type !== "element" || message?.srcElementName !== "lev");
+
+    await pipeline.stop();
+
+    expect(message?.peak).toBeInstanceOf(Array);
+  });
 });

--- a/src/ts/element-props.test.ts
+++ b/src/ts/element-props.test.ts
@@ -76,19 +76,19 @@ describe.concurrent("Element Properties", () => {
     // Test setting num-buffers property with bigint
     queue.setElementProperty("max-size-time", 1000000000n);
     const maxSizeTime = queue.getElementProperty("max-size-time");
-    expect(maxSizeTime?.type).toBe("bigint");
+    expect(maxSizeTime?.type).toBe("primitive");
     expect(maxSizeTime?.value).toBe(1000000000n);
 
     // Test setting num-buffers property with number
     queue.setElementProperty("max-size-time", 1000);
     const maxSizeTime2 = queue.getElementProperty("max-size-time");
-    expect(maxSizeTime2?.type).toBe("bigint");
+    expect(maxSizeTime2?.type).toBe("primitive");
     expect(maxSizeTime2?.value).toBe(1000n);
 
     // Test setting numbers larger then uint32 within javaScript number (which is a float64)
     queue.setElementProperty("max-size-time", Number.MAX_SAFE_INTEGER);
     const maxSizeTime3 = queue.getElementProperty("max-size-time");
-    expect(maxSizeTime3?.type).toBe("bigint");
+    expect(maxSizeTime3?.type).toBe("primitive");
     expect(maxSizeTime3?.value).toBe(BigInt(Number.MAX_SAFE_INTEGER));
   });
 

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -9,7 +9,10 @@ const __dirname = dirname(__filename);
 // Get the project root directory (two levels up from __dirname)
 const projectRoot = join(__dirname, "../../");
 
-export type GStreamerPropertyValue = string | number | boolean | bigint;
+export type GStreamerPropertyPrimitiveValue = string | number | boolean | bigint;
+export type GStreamerPropertyValue =
+  | GStreamerPropertyPrimitiveValue
+  | GStreamerPropertyPrimitiveValue[];
 
 // Sample object returned for GST_VALUE_HOLDS_SAMPLE properties
 export type GStreamerSample = {
@@ -51,17 +54,15 @@ export type GstMessage = {
 // Extended return types including arrays, buffers, and samples
 export type GStreamerPropertyReturnValue =
   | GStreamerPropertyValue
-  | GStreamerPropertyValue[]
   | Record<string, GStreamerPropertyValue>
   | Buffer
   | GStreamerSample
   | null;
 
 export type GStreamerPropertyResult =
-  | { type: "primitive"; value: GStreamerPropertyValue }
-  | { type: "bigint"; value: GStreamerPropertyValue }
-  | { type: "array"; value: GStreamerPropertyValue[] }
-  | { type: "object"; value: Record<string, GStreamerPropertyValue | GStreamerPropertyValue[]> }
+  | { type: "primitive"; value: GStreamerPropertyPrimitiveValue }
+  | { type: "array"; value: GStreamerPropertyPrimitiveValue[] }
+  | { type: "object"; value: Record<string, GStreamerPropertyValue> }
   | { type: "buffer"; value: Buffer }
   | { type: "sample"; value: GStreamerSample }
   | null;

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -61,7 +61,7 @@ export type GStreamerPropertyResult =
   | { type: "primitive"; value: GStreamerPropertyValue }
   | { type: "bigint"; value: GStreamerPropertyValue }
   | { type: "array"; value: GStreamerPropertyValue[] }
-  | { type: "object"; value: Record<string, GStreamerPropertyValue> }
+  | { type: "object"; value: Record<string, GStreamerPropertyValue | GStreamerPropertyValue[]> }
   | { type: "buffer"; value: Buffer }
   | { type: "sample"; value: GStreamerSample }
   | null;


### PR DESCRIPTION
## Summary
Adding conversion for GValueArray to JS.

## Problem
In the bus messages for the Level Analysis elements, the structure values for rms, peak and decay were not converted to their JS counterparts because these values are GValueArrays, which the conversion did not account for.

## Solution
Added an additional check for GValueArray values in the boxed value conversion, and convert the values to JS 

## Todo
Will add tests to this PR as soon as I get to it.