### PR TITLE
Disable C++ exceptions to restore cross-distro ABI compatibility

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -13,13 +13,11 @@
             "dependencies": ["<!(node -p \"require('node-addon-api').gyp\")"],
             "defines": [
                 "NAPI_VERSION=<(napi_build_version)",
-                "NAPI_CPP_EXCEPTIONS",
+                "NAPI_DISABLE_CPP_EXCEPTIONS",
                 "BUILDING_NODE_EXTENSION",
             ],
-            "cflags!": ["-fno-exceptions"],
-            "cflags_cc!": ["-fno-exceptions"],
             "xcode_settings": {
-                "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
+                "GCC_ENABLE_CPP_EXCEPTIONS": "NO",
                 "CLANG_CXX_LIBRARY": "libc++",
                 "MACOSX_DEPLOYMENT_TARGET": "10.7",
             },
@@ -30,7 +28,6 @@
                         "<!@(node -p \"require('child_process').execSync('pkg-config --libs-only-L gstreamer-1.0 gstreamer-app-1.0 gstreamer-rtp-1.0 glib-2.0 gobject-2.0').toString().trim().split('-L').slice(1).map(f => f.trim().replace(/\\\\\\\\ /g, ' ')).join(';')\")"
                     ],
                 },
-                "VCCLCompilerTool": {"AdditionalOptions": ["/EHsc"]},
             },
             "include_dirs": [
                 "<!@(node -p \"require('node-addon-api').include\")",

--- a/src/cpp/async-workers.cpp
+++ b/src/cpp/async-workers.cpp
@@ -82,11 +82,12 @@ Napi::Object BusPopWorker::ConvertMessageToJs(const Napi::Env &env, GstMessage *
         Napi::Object *obj = data->second;
 
         const char *field_name = g_quark_to_string(field_id);
-        try {
-          Napi::Value js_value = TypeConversion::gvalue_to_js(env, value);
-          obj->Set(field_name, js_value);
-        } catch (...) {
+        Napi::Value js_value = TypeConversion::gvalue_to_js(env, value);
+        if (env.IsExceptionPending()) {
           // Skip fields that can't be converted
+          env.GetAndClearPendingException();
+        } else {
+          obj->Set(field_name, js_value);
         }
 
         return TRUE;

--- a/src/cpp/type-conversion.cpp
+++ b/src/cpp/type-conversion.cpp
@@ -432,11 +432,12 @@ namespace TypeConversion {
             Napi::Object *obj = data->second;
 
             const char *field_name = g_quark_to_string(field_id);
-            try {
-              Napi::Value js_value = gvalue_to_js(env, value);
-              obj->Set(field_name, js_value);
-            } catch (...) {
+            Napi::Value js_value = gvalue_to_js(env, value);
+            if (env.IsExceptionPending()) {
               // Skip fields that can't be converted
+              env.GetAndClearPendingException();
+            } else {
+              obj->Set(field_name, js_value);
             }
 
             return TRUE;
@@ -473,11 +474,12 @@ namespace TypeConversion {
         Napi::Object *obj = data->second;
 
         const char *field_name = g_quark_to_string(field_id);
-        try {
-          Napi::Value js_value = gvalue_to_js(env, value);
-          obj->Set(field_name, js_value);
-        } catch (...) {
+        Napi::Value js_value = gvalue_to_js(env, value);
+        if (env.IsExceptionPending()) {
           // Skip fields that can't be converted
+          env.GetAndClearPendingException();
+        } else {
+          obj->Set(field_name, js_value);
         }
 
         return TRUE;


### PR DESCRIPTION
This PR disables C++ exceptions in the native addon, which eliminates the
problematic symbol reference and makes the resulting `.node` portable across
all common Linux distributions without any build-time workaround.

## Root cause

GCC 13+ emits a reference to `__cxa_call_terminate@CXXABI_1.3.15` whenever
code is compiled with C++ exceptions enabled **and** the translation unit
contains a MUST_NOT_THROW region. MUST_NOT_THROW regions are generated for:

- implicitly-`noexcept` boundaries (destructors, special member functions),
- explicitly-`noexcept` functions that internally call throwing code,
- `delete` expressions.

`CXXABI_1.3.15` was added in GCC 13. Ubuntu 22.04's bundled `libstdc++.so.6`
(from GCC 11) only exports up to `CXXABI_1.3.13`, so loading fails.

The original `node-gstreamer-superficial` is unaffected because it uses
`nan`-style error returns and is built without C++ exceptions — there are
no MUST_NOT_THROW regions and the symbol is never emitted.

gst-kit had `NAPI_CPP_EXCEPTIONS` defined and removed `-fno-exceptions`
from the build flags, opting into the exception-based variant of
`node-addon-api`. Combined with GCC 13+ this produced binaries that
required `CXXABI_1.3.15` at runtime.

## Fix

Switch to the no-exceptions variant of `node-addon-api`. The vast majority
of the codebase was already using `Napi::Error::New(env, ...).ThrowAsJavaScriptException()`,
which is the N-API-level pending-exception pattern (sets a pending JS error
via `napi_throw_*` and returns) and does **not** rely on C++ exceptions —
so no changes were needed in those call sites.

The only three places using actual C++ `try/catch` were defensive
"skip-on-conversion-failure" guards inside `gst_structure_foreach`
callbacks. They were replaced with the equivalent pending-exception check:

```cpp
Napi::Value js_value = gvalue_to_js(env, value);
if (env.IsExceptionPending()) {
  env.GetAndClearPendingException();
} else {
  obj->Set(field_name, js_value);
}
```

Fixes #15 